### PR TITLE
Feature of endpoint makes user to be staff or an admin

### DIFF
--- a/server/controllers/user.controllers.js
+++ b/server/controllers/user.controllers.js
@@ -110,4 +110,37 @@ const getAllUsers = async (req, res) => {
     });
   };
 
-export { signUp, signIn, getAllUsers }
+
+  
+const toggleAccounttype = async (req, res) => {
+    const emailId = req.params.emailId;
+  
+    const { rows } = await query("SELECT * FROM users WHERE email = $1", [
+      emailId
+    ]);
+  
+    if (rows[0]) {
+      const newtype =
+        rows[0].type == "user" || rows[0].type == "staff" ? "admin" : "staff";
+  
+      await query(`UPDATE users SET type=$1 WHERE email=$2`, [newtype, emailId]);
+  
+      const printOu = [
+        {
+          Account: req.params.emailId,
+          message: `type updated successfully! your account is now: ${newtype}`
+        }
+      ];
+      res.status(200).send({
+        status: "200",
+        data: printOu
+      });
+    } else {
+      return res.status(404).send({
+        status: 404,
+        error: "No such account found"
+      });
+    }
+  };
+  
+export { signUp, signIn, getAllUsers, toggleAccounttype }

--- a/server/routes/user.routes.js
+++ b/server/routes/user.routes.js
@@ -2,8 +2,8 @@ import {
   validateSignUpData,
   validateSignInData
 } from "../middlewares/validation";
-import { signUp, signIn, getAllUsers} from "../controllers/user.controllers";
-import { verify, verifyStaff, verifyAdmin } from '../middlewares/verifyToken'
+import { signUp, signIn, getAllUsers, toggleAccounttype } from "../controllers/user.controllers";
+import { verify, verifyStaff, verifyAdmin } from "../middlewares/verifyToken";
 
 export default function(router) {
   router.route("/signup").post(validateSignUpData, signUp);
@@ -11,4 +11,8 @@ export default function(router) {
   router.route("/signin").post(validateSignInData, signIn);
 
   router.route("/users").get(verifyStaff, getAllUsers);
+
+  router
+    .route("/users/:emailId/switchrole")
+    .patch(verifyAdmin, toggleAccounttype);
 }


### PR DESCRIPTION
### Developer should create an endpoint where an Admin can makes user to be staff or an admin.

**As Developer**
**I want  to input existing user** 
**So that I can change his account to staff or admin**

### Acceptance Criteria

```gherkin
Scenario: 
Given user email 
When email parsed to endpoint created and an admin authorized to do so
Then Admin should be able to change his account type to staff or admin.
```

**Notes:**
endpoint: post ->  /users/<emailId>/switchrole

**Pivotal Tracker ID**
#[171562351](https://www.pivotaltracker.com/story/show/171562351)