### PR TITLE
Feature adding enpoint that deletes an account

### DIFF
--- a/server/controllers/account.controllers.js
+++ b/server/controllers/account.controllers.js
@@ -78,7 +78,6 @@ const getOneAccount = async (req, res) => {
 };
 
 
-
 const toggleAccountStatus = async (req, res) => {
 
     const accNumberID = parseInt((req.params.accNumber).replace(/[\W_]+/g, ''))
@@ -111,9 +110,38 @@ const toggleAccountStatus = async (req, res) => {
 };
 
 
+
+const deleteOneAccount = async (req, res) => {
+
+    const accNumberID = parseInt((req.params.accNumber).replace(/[\W_]+/g, ''))
+
+    const { rows } = await query('SELECT * FROM accounts WHERE accountnumber = $1', [accNumberID])
+
+    if (rows[0]) {
+
+        await query(`DELETE FROM accounts WHERE accountnumber=$1`, [accNumberID]) 
+
+        const printOu = [{
+            id: req.params.accNumberID,
+            message: "Account deleted successfully!",
+        }]
+        res.status(200).send({
+            status: "200",
+            data: printOu
+        })
+    } else {
+        return res.status(404).send({
+            status: 404,
+            error: "No such account found"
+        })
+    }
+
+};
+
 export {
     createAccount,
     getOneAccount,
     getAccounts,
-    toggleAccountStatus
+    toggleAccountStatus,
+    deleteOneAccount
 }

--- a/server/routes/account.routes.js
+++ b/server/routes/account.routes.js
@@ -1,17 +1,20 @@
-import { verify, verifyStaff, verifyAdmin } from '../middlewares/verifyToken';
+import { verify, verifyStaff, verifyAdmin } from "../middlewares/verifyToken";
 import {
   createAccount,
   getOneAccount,
   getAccounts,
-  toggleAccountStatus
-} from '../controllers/account.controllers';
+  toggleAccountStatus,
+  deleteOneAccount
+} from "../controllers/account.controllers";
 
 export default function(router) {
-  router.route('/accounts').post(verify, createAccount);
+  router.route("/accounts").post(verify, createAccount);
 
-  router.route('/accounts').get(verifyStaff, getAccounts);
+  router.route("/accounts").get(verifyStaff, getAccounts);
 
-  router.route('/accounts/:accNumber').get(verify, getOneAccount);
+  router.route("/accounts/:accNumber").get(verify, getOneAccount);
 
-  router.route('/accounts/:accNumber').patch(verifyAdmin, toggleAccountStatus);
+  router.route("/accounts/:accNumber").patch(verifyAdmin, toggleAccountStatus);
+
+  router.route("/accounts/:accNumber").delete(verifyStaff, deleteOneAccount);
 }


### PR DESCRIPTION
###  Admin can delete an admin or staff user account.

**As Developer**
**I want  to input existing account number** 
**So that I can delete that  account**

### Acceptance Criteria

```gherkin
Scenario: 
Given account number 
When account number parsed to endpoint parameters and an admin authorized to do so
Then should be able to delete that account.
```

**Notes:**
endpoint: delete ->  /accounts/<accountNumber>

**Pivotal tracker id**
[#171562427](https://www.pivotaltracker.com/story/show/171562427)